### PR TITLE
change references to zarf to the zarf-dev GH org

### DIFF
--- a/zarf@0.23.0-rc6.rb
+++ b/zarf@0.23.0-rc6.rb
@@ -9,7 +9,7 @@ class ZarfAT0230Rc6 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc6/zarf_v0.23.0-rc6_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc6/zarf_v0.23.0-rc6_Darwin_arm64"
       sha256 "b31b24459809b741122660e43ae97b2815fe31da7a7b469ad7a870cc26670e77"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0230Rc6 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc6/zarf_v0.23.0-rc6_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc6/zarf_v0.23.0-rc6_Darwin_amd64"
       sha256 "44e194bf98b8c80837b16143dc488cdfbcfb8e43d1caa8b0af7e5702f11befee"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0230Rc6 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc6/zarf_v0.23.0-rc6_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc6/zarf_v0.23.0-rc6_Linux_arm64"
       sha256 "55d21dcc73ce83e092350a20d96b374f9085252d7a83122ba24f0341e64ddcde"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0230Rc6 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc6/zarf_v0.23.0-rc6_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc6/zarf_v0.23.0-rc6_Linux_amd64"
       sha256 "ba2db3bfca389449f69bde4a4a93460ab52a50ff9661f82c6b2b43f8ebc70e0b"
 
       def install

--- a/zarf@0.23.0-rc7.rb
+++ b/zarf@0.23.0-rc7.rb
@@ -9,7 +9,7 @@ class ZarfAT0230Rc7 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc7/zarf_v0.23.0-rc7_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc7/zarf_v0.23.0-rc7_Darwin_amd64"
       sha256 "651bd971e90e41c0b4705990a62c594aed34b1d0f97ee3a1eae6eb154034468a"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0230Rc7 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc7/zarf_v0.23.0-rc7_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc7/zarf_v0.23.0-rc7_Darwin_arm64"
       sha256 "59cdb81ae0b0c32c8d461461ccd0d3a6bf68a660db77e5843903f6f2f44be8be"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0230Rc7 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc7/zarf_v0.23.0-rc7_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc7/zarf_v0.23.0-rc7_Linux_arm64"
       sha256 "b4500ce50d775cf639425d5b470d921f8943df90b26762ca93cf67d01d6b55b8"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0230Rc7 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc7/zarf_v0.23.0-rc7_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc7/zarf_v0.23.0-rc7_Linux_amd64"
       sha256 "0905692c10e1a04f05c236d8b5a307620f0bed9de9e0a4e2f0b899643161c8da"
 
       def install

--- a/zarf@0.23.0.rb
+++ b/zarf@0.23.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0230 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0/zarf_v0.23.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0/zarf_v0.23.0_Darwin_amd64"
       sha256 "a195ca55743f6e0530a74dbb4316be7fac9f44c3540b219eecd1d02fb0c76d24"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0230 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0/zarf_v0.23.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0/zarf_v0.23.0_Darwin_arm64"
       sha256 "f8809168b036a957f751980850868c1f62f26efaf4809a8d4e4bf0d73ddcd614"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0230 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0/zarf_v0.23.0_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0/zarf_v0.23.0_Linux_amd64"
       sha256 "80ac7c203fdc4f86d7530d1c12a29e00b240f20ed5437e59231e35903b2c1e08"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0230 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0/zarf_v0.23.0_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0/zarf_v0.23.0_Linux_arm64"
       sha256 "967ddf24ae9f371b51c76e78bfb649456e5e182fbcfaf1fc690ecf5692b39a21"
 
       def install

--- a/zarf@0.23.1.rb
+++ b/zarf@0.23.1.rb
@@ -9,7 +9,7 @@ class ZarfAT0231 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.1/zarf_v0.23.1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.1/zarf_v0.23.1_Darwin_amd64"
       sha256 "11be23aa7866ca7078ad1744f905c2473633daeda204041f57d229d965415c82"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0231 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.1/zarf_v0.23.1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.1/zarf_v0.23.1_Darwin_arm64"
       sha256 "acaa24953f5106bfed31f5306ed78fcd1ed0703e64f04ae1004311696e5f49da"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0231 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.1/zarf_v0.23.1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.1/zarf_v0.23.1_Linux_arm64"
       sha256 "dbb95c5d80cb585d5493634c5ce1c4154899be5d875e81010a35ce2d243dba3c"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0231 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.1/zarf_v0.23.1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.1/zarf_v0.23.1_Linux_amd64"
       sha256 "bb10ee2f9a72b71f5d319af7917897757a9a0ffa64b4e788b654e408d581ab19"
 
       def install

--- a/zarf@0.23.2.rb
+++ b/zarf@0.23.2.rb
@@ -9,7 +9,7 @@ class ZarfAT0232 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.2/zarf_v0.23.2_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.2/zarf_v0.23.2_Darwin_arm64"
       sha256 "cb668e6ec6b3c857877baa729dcd036a6a931e5757090026f033c92731877625"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0232 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.2/zarf_v0.23.2_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.2/zarf_v0.23.2_Darwin_amd64"
       sha256 "3756bb28b750029cf2e0a64f859057c380f485461f42d3d473c187f899b1f726"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0232 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.2/zarf_v0.23.2_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.2/zarf_v0.23.2_Linux_arm64"
       sha256 "513f1c6b30216cacf7f95c642449e538928df9d53a49ea125b068820df4a04a3"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0232 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.2/zarf_v0.23.2_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.2/zarf_v0.23.2_Linux_amd64"
       sha256 "da723e937f9d0e92fb2c9155fe4f8291461bee2091aeee56f0374ae66dd72857"
 
       def install

--- a/zarf@0.23.3.rb
+++ b/zarf@0.23.3.rb
@@ -9,7 +9,7 @@ class ZarfAT0233 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.3/zarf_v0.23.3_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.3/zarf_v0.23.3_Darwin_amd64"
       sha256 "f24365600e43e9fec192eda7e6f9c0640814fa69a69fdcbcbce72a85f70e07b6"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0233 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.3/zarf_v0.23.3_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.3/zarf_v0.23.3_Darwin_arm64"
       sha256 "ef2155d41dea7bb98f76960f8e86c9eda1dd0c497378c67085556a36dcf2e2db"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0233 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.3/zarf_v0.23.3_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.3/zarf_v0.23.3_Linux_amd64"
       sha256 "f8a5e2c1495097ea8f2c8be3215bc3006788cc927e6164ad59c835550b8055d0"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0233 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.3/zarf_v0.23.3_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.3/zarf_v0.23.3_Linux_arm64"
       sha256 "cb37eff93f466d478d63807acf5e7b9958a132649a78776e1458cfa1522af319"
 
       def install

--- a/zarf@0.23.4.rb
+++ b/zarf@0.23.4.rb
@@ -9,7 +9,7 @@ class ZarfAT0234 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.4/zarf_v0.23.4_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.4/zarf_v0.23.4_Darwin_amd64"
       sha256 "d951601520c87e6f17397b75e8ef6d0995428d4d85ed69637c324140136977d0"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0234 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.4/zarf_v0.23.4_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.4/zarf_v0.23.4_Darwin_arm64"
       sha256 "67b1ba769f20733359790796e4c0690719ea6d90cbd3259634fdeec880f1184a"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0234 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.4/zarf_v0.23.4_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.4/zarf_v0.23.4_Linux_amd64"
       sha256 "643bd9e7f9777436b0f298c0628d74c6636592cb872907a3dbd45e27bdb169e6"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0234 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.4/zarf_v0.23.4_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.4/zarf_v0.23.4_Linux_arm64"
       sha256 "ba8216197e6d58500d6d2f96a120c931de6cea3e02308d8082729f1d462467af"
 
       def install

--- a/zarf@0.23.5.rb
+++ b/zarf@0.23.5.rb
@@ -9,7 +9,7 @@ class ZarfAT0235 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.5/zarf_v0.23.5_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.5/zarf_v0.23.5_Darwin_amd64"
       sha256 "a764aac1b02333edc710b1551b95ce6654adc63dce038803926a993f181fa203"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0235 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.5/zarf_v0.23.5_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.5/zarf_v0.23.5_Darwin_arm64"
       sha256 "c9f6a409416c83979039e6ebf806ef2a535d9827471dff98be38d514862e1c26"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0235 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.5/zarf_v0.23.5_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.5/zarf_v0.23.5_Linux_arm64"
       sha256 "60a6d1d64f92d72fee57bd3ea2a78b400c98c4c99bef32e4b7cbc9d0a8fbf66b"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0235 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.5/zarf_v0.23.5_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.5/zarf_v0.23.5_Linux_amd64"
       sha256 "7ba8db5c89207fbbcaa7afd26aae8682030af687f539e665f961825073239bc1"
 
       def install

--- a/zarf@0.23.6.rb
+++ b/zarf@0.23.6.rb
@@ -9,7 +9,7 @@ class ZarfAT0236 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.6/zarf_v0.23.6_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.6/zarf_v0.23.6_Darwin_amd64"
       sha256 "0035119bcd011f16b7d8751456d8dea00676947411230f468646660d037b8719"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0236 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.6/zarf_v0.23.6_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.6/zarf_v0.23.6_Darwin_arm64"
       sha256 "e99e64a8af27eaf43e755f0abd3927e06115a88ff9034b86acd697249a7fa570"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0236 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.6/zarf_v0.23.6_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.6/zarf_v0.23.6_Linux_arm64"
       sha256 "20fdfa636e9c5a0ddfd300ff8814797f351ef1c9c7724fb7038f0a39dc6c84d1"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0236 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.6/zarf_v0.23.6_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.6/zarf_v0.23.6_Linux_amd64"
       sha256 "6c56d208661159d6fa75e83cc46bc3faa9a66fd46b9ef4d0c4d6e8149fcceee9"
 
       def install

--- a/zarf@0.24.0-rc3.rb
+++ b/zarf@0.24.0-rc3.rb
@@ -9,7 +9,7 @@ class ZarfAT0240Rc3 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0-rc3/zarf_v0.24.0-rc3_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0-rc3/zarf_v0.24.0-rc3_Darwin_arm64"
       sha256 "dd1b2c9fa459a24d923496a7ca1b9616463476d78adb3b398b27dcc9a2ab5542"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0240Rc3 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0-rc3/zarf_v0.24.0-rc3_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0-rc3/zarf_v0.24.0-rc3_Darwin_amd64"
       sha256 "deab1b1fcfaf97f7269cdf6ac8e40ebce9cf137076cce61befba991ed329479a"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0240Rc3 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0-rc3/zarf_v0.24.0-rc3_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0-rc3/zarf_v0.24.0-rc3_Linux_arm64"
       sha256 "8890d0b1cb177d0931021c5e06ee308633fe4af2ce12ae69b36c52b02b7a73db"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0240Rc3 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0-rc3/zarf_v0.24.0-rc3_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0-rc3/zarf_v0.24.0-rc3_Linux_amd64"
       sha256 "476d8d138fe51a97527fff3d02eb188966727a13ebf88e21d867e7f944ef6a9e"
 
       def install

--- a/zarf@0.24.0-rc4.rb
+++ b/zarf@0.24.0-rc4.rb
@@ -9,7 +9,7 @@ class ZarfAT0240Rc4 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0-rc4/zarf_v0.24.0-rc4_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0-rc4/zarf_v0.24.0-rc4_Darwin_amd64"
       sha256 "80b7e2ab942c0c0051a4da2a35e01efc8fd7b4366054c7c84e57d5d67d1396d5"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0240Rc4 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0-rc4/zarf_v0.24.0-rc4_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0-rc4/zarf_v0.24.0-rc4_Darwin_arm64"
       sha256 "de165687cab6f3f938b32c6eabd1c03ac93a5537d4df15ecb68d232113c6e211"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0240Rc4 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0-rc4/zarf_v0.24.0-rc4_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0-rc4/zarf_v0.24.0-rc4_Linux_amd64"
       sha256 "283a3b9ea9e8698e6633a12e0961ee0f4efd25c9d40480db2a4a765c2c610d3f"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0240Rc4 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0-rc4/zarf_v0.24.0-rc4_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0-rc4/zarf_v0.24.0-rc4_Linux_arm64"
       sha256 "927e97c39d0fcccdaf60b14731847477465974d8e6678a2bcac35a8ecfdc697f"
 
       def install

--- a/zarf@0.24.0-rc5.rb
+++ b/zarf@0.24.0-rc5.rb
@@ -9,7 +9,7 @@ class ZarfAT0240Rc5 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0-rc5/zarf_v0.24.0-rc5_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0-rc5/zarf_v0.24.0-rc5_Darwin_arm64"
       sha256 "a6bc9ed4d164cbafe14b9af60fb06a37ed8e05896ead0454f3c9b3364cb56db5"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0240Rc5 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0-rc5/zarf_v0.24.0-rc5_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0-rc5/zarf_v0.24.0-rc5_Darwin_amd64"
       sha256 "43c2da44c2d677b969efe191054dc51f3fa47eb6dbefef4f41a9713aa8eff139"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0240Rc5 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0-rc5/zarf_v0.24.0-rc5_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0-rc5/zarf_v0.24.0-rc5_Linux_arm64"
       sha256 "0f8bbad91428801a1ffedcfe8a5a1157dc290da13b3e8de97c58202da1732a52"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0240Rc5 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0-rc5/zarf_v0.24.0-rc5_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0-rc5/zarf_v0.24.0-rc5_Linux_amd64"
       sha256 "78b22b926a7c0974a6dd881f7875a203113844d63dbe71e98e46600b07173796"
 
       def install

--- a/zarf@0.24.0.rb
+++ b/zarf@0.24.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0240 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0/zarf_v0.24.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0/zarf_v0.24.0_Darwin_arm64"
       sha256 "39c206b354a2590ee4b92a881a7917dc8a18c9921676d7ee1b2a379951aa9598"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0240 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0/zarf_v0.24.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0/zarf_v0.24.0_Darwin_amd64"
       sha256 "7f5a2168051fa74dfdb03732e0744a3a67c53c526b0803151d2b2e6cb139ff69"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0240 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0/zarf_v0.24.0_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0/zarf_v0.24.0_Linux_arm64"
       sha256 "54a3f8d96951cb6d8c09a13c1bdc9eddefa9e51ac2ce7b40bb80b2397cbd0872"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0240 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.0/zarf_v0.24.0_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.0/zarf_v0.24.0_Linux_amd64"
       sha256 "806d37443b2519e55cbd10926e4dc484608ea118c8e8fbefbe68c7625e006006"
 
       def install

--- a/zarf@0.24.1.rb
+++ b/zarf@0.24.1.rb
@@ -9,7 +9,7 @@ class ZarfAT0241 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.1/zarf_v0.24.1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.1/zarf_v0.24.1_Darwin_amd64"
       sha256 "3201fe1ffd7f4bd355bc2ccca948c29f9d27bf42785953b90951e7fd7c904b6a"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0241 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.1/zarf_v0.24.1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.1/zarf_v0.24.1_Darwin_arm64"
       sha256 "b8bd9a461fe2f23a4d8be19ebcf5e933838d0dfadb21e85b0c87407e60a05b62"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0241 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.1/zarf_v0.24.1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.1/zarf_v0.24.1_Linux_arm64"
       sha256 "d585e16eef874451f8f8c43b250d029d3163683cd6813a1ecdf9371ea1a2e097"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0241 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.1/zarf_v0.24.1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.1/zarf_v0.24.1_Linux_amd64"
       sha256 "5439ad036c388256841e11170eef4269aecd403bdc5fb4ba4edf276366b3c182"
 
       def install

--- a/zarf@0.24.2.rb
+++ b/zarf@0.24.2.rb
@@ -9,7 +9,7 @@ class ZarfAT0242 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.2/zarf_v0.24.2_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.2/zarf_v0.24.2_Darwin_amd64"
       sha256 "e572235d899adaa2a961e9fa66aa2d33f73e83455779e629d022f55ddf795c2f"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0242 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.2/zarf_v0.24.2_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.2/zarf_v0.24.2_Darwin_arm64"
       sha256 "8b1a86b620a34e6ffbdcd47e2469dfc3b9e75960070d4cd297a4fd66d8442992"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0242 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.2/zarf_v0.24.2_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.2/zarf_v0.24.2_Linux_amd64"
       sha256 "e020001171b1d1e687758c9d6766185075089f52dc1dc821436687f28756baf7"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0242 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.2/zarf_v0.24.2_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.2/zarf_v0.24.2_Linux_arm64"
       sha256 "82a646ae2f8654ed90be678cd0f5eab17275d3e776abac9dfb41308a2b329064"
 
       def install

--- a/zarf@0.24.3.rb
+++ b/zarf@0.24.3.rb
@@ -9,7 +9,7 @@ class ZarfAT0243 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.3/zarf_v0.24.3_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.3/zarf_v0.24.3_Darwin_amd64"
       sha256 "ba90c112abe9173df7a32b1b05d2a783375ae7acb7d060586d7239dc0f0a7a57"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0243 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.3/zarf_v0.24.3_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.3/zarf_v0.24.3_Darwin_arm64"
       sha256 "c6e880e735f2a67bd4f5cba3e910df1be0f0fece387b7e4223b719071d4a0625"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0243 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.3/zarf_v0.24.3_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.3/zarf_v0.24.3_Linux_amd64"
       sha256 "e3da3d93313ce6a7fda0cac304baaa4935662aaa78b5fe2d0f3852d38f98781a"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0243 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.24.3/zarf_v0.24.3_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.24.3/zarf_v0.24.3_Linux_arm64"
       sha256 "b44f1a85b61751acc6d5835f27585899821cf224e5d04fe33ee93f5d72aa1070"
 
       def install

--- a/zarf@0.25.0-rc1.rb
+++ b/zarf@0.25.0-rc1.rb
@@ -9,7 +9,7 @@ class ZarfAT0250Rc1 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.0-rc1/zarf_v0.25.0-rc1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.0-rc1/zarf_v0.25.0-rc1_Darwin_amd64"
       sha256 "1d9e3021a10e4166b7e916ac05711f893ea8a1389ead175d66dd11dd71501849"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0250Rc1 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.0-rc1/zarf_v0.25.0-rc1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.0-rc1/zarf_v0.25.0-rc1_Darwin_arm64"
       sha256 "c3fb11ff615cbf51384f5a8bb25ef013b1af7576fe2d6c159fe149acbf2122ed"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0250Rc1 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.0-rc1/zarf_v0.25.0-rc1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.0-rc1/zarf_v0.25.0-rc1_Linux_amd64"
       sha256 "23f26dde4b43e712500644c4d6ec5ca8f6526f5d0701ba55738885fcc79b571a"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0250Rc1 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.0-rc1/zarf_v0.25.0-rc1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.0-rc1/zarf_v0.25.0-rc1_Linux_arm64"
       sha256 "5d7340860e9c17dcd708a30164b05d0d38018cdfc7f33b4d0e741e99215e0abf"
 
       def install

--- a/zarf@0.25.0-rc2.rb
+++ b/zarf@0.25.0-rc2.rb
@@ -9,7 +9,7 @@ class ZarfAT0250Rc2 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.0-rc2/zarf_v0.25.0-rc2_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.0-rc2/zarf_v0.25.0-rc2_Darwin_amd64"
       sha256 "505724b587fbf913ca1beea613d1f1e59cb561dd9393ea598611fd1568dfa049"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0250Rc2 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.0-rc2/zarf_v0.25.0-rc2_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.0-rc2/zarf_v0.25.0-rc2_Darwin_arm64"
       sha256 "c50a1a60e8fe3fe8b242c607ce657d052514555325a533d4093f0d4cb2f77689"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0250Rc2 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.0-rc2/zarf_v0.25.0-rc2_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.0-rc2/zarf_v0.25.0-rc2_Linux_amd64"
       sha256 "95c270acee0ee39288ff6ccad1173cc51f7dbb64af19a31dce60c446ce168c18"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0250Rc2 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.0-rc2/zarf_v0.25.0-rc2_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.0-rc2/zarf_v0.25.0-rc2_Linux_arm64"
       sha256 "0f100cc4bfe380b68a22db292e61168051a290f9c90848664e7fa4bec7685b30"
 
       def install

--- a/zarf@0.25.0.rb
+++ b/zarf@0.25.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0250 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.0/zarf_v0.25.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.0/zarf_v0.25.0_Darwin_arm64"
       sha256 "41be9b0bee268fa8be575a0e13c4c3e1c20da9698aaeceae72907129cc237bb8"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0250 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.0/zarf_v0.25.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.0/zarf_v0.25.0_Darwin_amd64"
       sha256 "af41fc87a71fc598533bfd0be046e5cdb63199ca3ebdbc29c085742554afd854"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0250 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.0/zarf_v0.25.0_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.0/zarf_v0.25.0_Linux_amd64"
       sha256 "29fba1df72b63543ae6d8f9fcc54d239670105ef5403c6d564c3f078587a3a57"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0250 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.0/zarf_v0.25.0_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.0/zarf_v0.25.0_Linux_arm64"
       sha256 "87a98877887cf2b232db4e88d7fe35eca9f781211a93c12652263a2b361e25f3"
 
       def install

--- a/zarf@0.25.1.rb
+++ b/zarf@0.25.1.rb
@@ -9,7 +9,7 @@ class ZarfAT0251 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.1/zarf_v0.25.1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.1/zarf_v0.25.1_Darwin_amd64"
       sha256 "94b804671252dfb1712074ccc6ab257568ceffc40833962d017f0bc75a88390b"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0251 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.1/zarf_v0.25.1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.1/zarf_v0.25.1_Darwin_arm64"
       sha256 "3aa1230e0a67b6d92ea0d31f00e8a6d97bc723a2ef3a4d569d666da316b48830"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0251 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.1/zarf_v0.25.1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.1/zarf_v0.25.1_Linux_arm64"
       sha256 "fae4d0329ba622cf566fbc8e93d8ce167c07a12249ede16adab3611f04e74ac2"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0251 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.1/zarf_v0.25.1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.1/zarf_v0.25.1_Linux_amd64"
       sha256 "8e1ddf5455d74f5904355780ac1cf2e0a3f394586828e5417888efa9901c8b94"
 
       def install

--- a/zarf@0.25.2.rb
+++ b/zarf@0.25.2.rb
@@ -9,7 +9,7 @@ class ZarfAT0252 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.2/zarf_v0.25.2_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.2/zarf_v0.25.2_Darwin_amd64"
       sha256 "1a52eeb6f7c09b2364e7d852301356784f58b90474e2fa0cf38fac0389d66858"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0252 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.2/zarf_v0.25.2_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.2/zarf_v0.25.2_Darwin_arm64"
       sha256 "daa42f4555369f5d87535bf7fdabe181750a6c8512f84d66d335f1fcb62e1086"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0252 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.2/zarf_v0.25.2_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.2/zarf_v0.25.2_Linux_arm64"
       sha256 "36b36e90c3f249cd4fae0eef0b63add52d5a49b22c9f175f662af2b331929042"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0252 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.25.2/zarf_v0.25.2_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.25.2/zarf_v0.25.2_Linux_amd64"
       sha256 "05e2b2f2722d24ec034d40f8620162d19dafc8ba9e1404051011c0f5224f5563"
 
       def install

--- a/zarf@0.26.0.rb
+++ b/zarf@0.26.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0260 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.0/zarf_v0.26.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.0/zarf_v0.26.0_Darwin_amd64"
       sha256 "02cec31d62f5a3d35e72acb785eddbc4d733169a315cce9681f677e5d757bab1"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0260 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.0/zarf_v0.26.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.0/zarf_v0.26.0_Darwin_arm64"
       sha256 "c99d8260e6d0d35848de10e40f837cc32259854020baeca0ff9ad0e8075c2d39"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0260 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.0/zarf_v0.26.0_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.0/zarf_v0.26.0_Linux_amd64"
       sha256 "5cd7624d069049663d9189c1c1642644df8ba0462bfa27a1abd49059b79a92cd"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0260 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.0/zarf_v0.26.0_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.0/zarf_v0.26.0_Linux_arm64"
       sha256 "5abc4749678ab370fd3fb77b9ab808b689684d0f3c54f62ec6a07bf453cbf444"
 
       def install

--- a/zarf@0.26.1.rb
+++ b/zarf@0.26.1.rb
@@ -9,7 +9,7 @@ class ZarfAT0261 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.1/zarf_v0.26.1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.1/zarf_v0.26.1_Darwin_amd64"
       sha256 "850869a373153c0909831b586e7d0d27b7e344aad663545e784d320d72c9d43b"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0261 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.1/zarf_v0.26.1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.1/zarf_v0.26.1_Darwin_arm64"
       sha256 "cb65f0649193e8a89841461c5fadb0647c8f82cb3433225e7e21612a4e52b793"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0261 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.1/zarf_v0.26.1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.1/zarf_v0.26.1_Linux_amd64"
       sha256 "c98deaf3bced23dae73a182882fa6f66b647c532117e1b394d9e95fac8a178e5"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0261 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.1/zarf_v0.26.1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.1/zarf_v0.26.1_Linux_arm64"
       sha256 "8536f04ac40083935b5f9c3eb28c3b1f680a9623a910d12d92bd0cb42ad2fe1a"
 
       def install

--- a/zarf@0.26.2.rb
+++ b/zarf@0.26.2.rb
@@ -9,7 +9,7 @@ class ZarfAT0262 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.2/zarf_v0.26.2_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.2/zarf_v0.26.2_Darwin_amd64"
       sha256 "e79251f758b8b469f1ade2e3948ae0c45ac267dd0a038f08eb9f76f4979d73ad"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0262 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.2/zarf_v0.26.2_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.2/zarf_v0.26.2_Darwin_arm64"
       sha256 "97964affa13cabc13a2e4a3b2fd7db00b11258c3846902f6d214b443613d5bb0"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0262 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.2/zarf_v0.26.2_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.2/zarf_v0.26.2_Linux_arm64"
       sha256 "fc93b1b9d4aff0cc4d7d7ed80ecad2268ebe1b294f9ab3f9f3f0f7206ab6c6df"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0262 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.2/zarf_v0.26.2_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.2/zarf_v0.26.2_Linux_amd64"
       sha256 "2f0864f8c0951ce0d22b6ee06f0922d7d50a30eee356e89341f078056e84f259"
 
       def install

--- a/zarf@0.26.3.rb
+++ b/zarf@0.26.3.rb
@@ -9,7 +9,7 @@ class ZarfAT0263 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.3/zarf_v0.26.3_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.3/zarf_v0.26.3_Darwin_amd64"
       sha256 "fc269f622b7ee454759fc9d678a742bd249718805732289c384b754c1c13183d"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0263 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.3/zarf_v0.26.3_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.3/zarf_v0.26.3_Darwin_arm64"
       sha256 "da0eb885c32795133fb134b0cb0fd7d7fd2944ea42e5103b30c95bcef3128e49"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0263 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.3/zarf_v0.26.3_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.3/zarf_v0.26.3_Linux_arm64"
       sha256 "621956c7b6424e9f1eae39f2f35fdc40459749e84d64378dd40007fdc907f0e8"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0263 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.3/zarf_v0.26.3_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.3/zarf_v0.26.3_Linux_amd64"
       sha256 "23f3409616bc1db8492c01351868b617f830b674631a3ce7e30b2c27f3a0252a"
 
       def install

--- a/zarf@0.26.4.rb
+++ b/zarf@0.26.4.rb
@@ -9,7 +9,7 @@ class ZarfAT0264 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.4/zarf_v0.26.4_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.4/zarf_v0.26.4_Darwin_arm64"
       sha256 "f38ecc2e2cda0c2d6852df53054a5d977d1ca97e1206f95ab45cb447a53e194a"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0264 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.4/zarf_v0.26.4_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.4/zarf_v0.26.4_Darwin_amd64"
       sha256 "89e3254b787f227d51dcd130d732a6401d46b9cc3fbee21799d782064f5d6d13"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0264 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.4/zarf_v0.26.4_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.4/zarf_v0.26.4_Linux_arm64"
       sha256 "fd72b722bf91ad486247ff3575a49fe2e37d4743f23aef3f0f625255163b2292"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0264 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.26.4/zarf_v0.26.4_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.26.4/zarf_v0.26.4_Linux_amd64"
       sha256 "b618531d52f9e1ebd3680ce87a10c70f46110ce20a6c7547c0f39a75459c2a55"
 
       def install

--- a/zarf@0.27.0.rb
+++ b/zarf@0.27.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0270 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.27.0/zarf_v0.27.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.27.0/zarf_v0.27.0_Darwin_amd64"
       sha256 "078e0c2d0201c58ffe137db370871da3dec272a540dbaf9f77a5e0bef130cdd5"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0270 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.27.0/zarf_v0.27.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.27.0/zarf_v0.27.0_Darwin_arm64"
       sha256 "4f5f93fb3ca23f1f05bed6db052bfadfac55c99e61f1b12c079729f519f48ed4"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0270 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.27.0/zarf_v0.27.0_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.27.0/zarf_v0.27.0_Linux_amd64"
       sha256 "0f075a793a6c7fc0d268855feeacfdadfa03a4f3657475ee1538813a94f12bdf"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0270 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.27.0/zarf_v0.27.0_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.27.0/zarf_v0.27.0_Linux_arm64"
       sha256 "52d5f0cd88282ee2e276585728383d5583eaa77eb3642af6236f33d8f7ead64a"
 
       def install

--- a/zarf@0.27.1.rb
+++ b/zarf@0.27.1.rb
@@ -9,7 +9,7 @@ class ZarfAT0271 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.27.1/zarf_v0.27.1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.27.1/zarf_v0.27.1_Darwin_amd64"
       sha256 "983dc79837c6f26e200d02102e2bfca5047f078d31a50ea7f6561eba53a499f1"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0271 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.27.1/zarf_v0.27.1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.27.1/zarf_v0.27.1_Darwin_arm64"
       sha256 "b1abd29df24ff8fea26c99e47e2e14543c015f713a573e9163cd8ea35e4121e8"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0271 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.27.1/zarf_v0.27.1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.27.1/zarf_v0.27.1_Linux_arm64"
       sha256 "5173a29207f89b92ded301b197fb1ec138275f182512700befd9c2d38c658f76"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0271 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.27.1/zarf_v0.27.1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.27.1/zarf_v0.27.1_Linux_amd64"
       sha256 "ddcf3f13087d6a2bb5b11dd5b088e5a88245b2208409573f4b0f4a0dbb5b2e46"
 
       def install

--- a/zarf@0.28.0.rb
+++ b/zarf@0.28.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0280 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.0/zarf_v0.28.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.0/zarf_v0.28.0_Darwin_amd64"
       sha256 "137f6c7a36ec94bcd70075a70bee47ad124efa68dca84160c940084d40df1d7c"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0280 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.0/zarf_v0.28.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.0/zarf_v0.28.0_Darwin_arm64"
       sha256 "a1d3a88bae000e6915b2091836afb8ea130d54378e250152601aa20c8532a40f"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0280 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.0/zarf_v0.28.0_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.0/zarf_v0.28.0_Linux_amd64"
       sha256 "3e471b7b644c723f28bc8df51ac4d71770ce124583c727ef49eb2474f33acbd6"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0280 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.0/zarf_v0.28.0_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.0/zarf_v0.28.0_Linux_arm64"
       sha256 "a9700faf43849ca3ff97a2b054d3ec399379181a11096526cb18e0cb2439322c"
 
       def install

--- a/zarf@0.28.1.rb
+++ b/zarf@0.28.1.rb
@@ -9,7 +9,7 @@ class ZarfAT0281 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.1/zarf_v0.28.1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.1/zarf_v0.28.1_Darwin_amd64"
       sha256 "b97eaee15dfe7465fb426822443e15dda8a8d7d3aceedfa88524b03e305e9469"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0281 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.1/zarf_v0.28.1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.1/zarf_v0.28.1_Darwin_arm64"
       sha256 "57940c749afd8aaf134f979ef582df3ffe6160ec633323e838bce4ee7a262a41"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0281 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.1/zarf_v0.28.1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.1/zarf_v0.28.1_Linux_amd64"
       sha256 "c09aac2c1bd7b567936987e37cc2c2922ec2b57f7b2670681a836cf9db4d59ad"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0281 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.1/zarf_v0.28.1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.1/zarf_v0.28.1_Linux_arm64"
       sha256 "452966c8794c61cce3954e1e2a4c8a0432d32ff30c88fb353ca4b804b3f3fc5d"
 
       def install

--- a/zarf@0.28.2.rb
+++ b/zarf@0.28.2.rb
@@ -9,7 +9,7 @@ class ZarfAT0282 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.2/zarf_v0.28.2_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.2/zarf_v0.28.2_Darwin_amd64"
       sha256 "4d84ebb47a5ede6e4ee1c8ff96c4fa9fd36cf6b2179d90efcc87cfae69ff1552"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0282 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.2/zarf_v0.28.2_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.2/zarf_v0.28.2_Darwin_arm64"
       sha256 "8d5cea5ce7b49b72d114f9517da83a24261f029facf18e258437da8db4fa361a"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0282 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.2/zarf_v0.28.2_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.2/zarf_v0.28.2_Linux_amd64"
       sha256 "fcd0fcf68a5311f98297f4d2fe017b94cddf1b7d1186b41fb3ed3354fa312b37"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0282 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.2/zarf_v0.28.2_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.2/zarf_v0.28.2_Linux_arm64"
       sha256 "e3d4d86eb36e5757d177d838b0f2393bd6c6719990844f79f821d1462900124c"
 
       def install

--- a/zarf@0.28.3.rb
+++ b/zarf@0.28.3.rb
@@ -9,7 +9,7 @@ class ZarfAT0283 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.3/zarf_v0.28.3_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.3/zarf_v0.28.3_Darwin_amd64"
       sha256 "f05b3fc78c0398b340445f0f3ac745391403b08dae7196ffec04c437580e66ba"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0283 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.3/zarf_v0.28.3_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.3/zarf_v0.28.3_Darwin_arm64"
       sha256 "632650649209298343f2b3c4d40bd75f75ef4dd5ce5eefb55b6fc422919e4dd0"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0283 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.3/zarf_v0.28.3_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.3/zarf_v0.28.3_Linux_amd64"
       sha256 "3c87c65af19f7e1408e553440c7a8ff5bb15809f71fb8a390d761940c7f9d7aa"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0283 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.3/zarf_v0.28.3_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.3/zarf_v0.28.3_Linux_arm64"
       sha256 "936ead5bad5fd09433aecbfaa15e99dfc1fa624070065ceab745e3d79ccc0b2b"
 
       def install

--- a/zarf@0.28.4.rb
+++ b/zarf@0.28.4.rb
@@ -9,7 +9,7 @@ class ZarfAT0284 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.4/zarf_v0.28.4_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.4/zarf_v0.28.4_Darwin_amd64"
       sha256 "c6ed56b653faf97f9bf373ae3ff43e131c4af3942e1c24cffe54e2202e320acf"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0284 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.4/zarf_v0.28.4_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.4/zarf_v0.28.4_Darwin_arm64"
       sha256 "5e6a0fafae1d434245c3ae01dcfcba3dcf9a3c2f0a6dd87488d95a4abb83d4a7"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0284 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.4/zarf_v0.28.4_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.4/zarf_v0.28.4_Linux_arm64"
       sha256 "2e55f37017199efbcb54f4310b5ee85370fe1ece516912401bbbf6c1a20332c2"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0284 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.28.4/zarf_v0.28.4_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.28.4/zarf_v0.28.4_Linux_amd64"
       sha256 "32ef034bb791580a839d2cf024a41a071238f325c30ca4204dd3b910fbfe226c"
 
       def install

--- a/zarf@0.29.0.rb
+++ b/zarf@0.29.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0290 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.29.0/zarf_v0.29.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.29.0/zarf_v0.29.0_Darwin_amd64"
       sha256 "987f3e93e0bf2560f55c4567239f22880a12f57025a92b1dd8fe4dd644d3a4be"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0290 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.29.0/zarf_v0.29.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.29.0/zarf_v0.29.0_Darwin_arm64"
       sha256 "3e870d4cf950aa1f130f386e10d1a95ce764eb6e0c8478fe111b3082057dea51"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0290 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.29.0/zarf_v0.29.0_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.29.0/zarf_v0.29.0_Linux_amd64"
       sha256 "797329601aa16c1882a771652e91710b1fa26a63e79298b8aef732bfae3b848b"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0290 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.29.0/zarf_v0.29.0_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.29.0/zarf_v0.29.0_Linux_arm64"
       sha256 "c5a6fe7c511b9127676488abb653b5af17c3ed962542abd5b5a7ee4cd134ab0a"
 
       def install

--- a/zarf@0.29.1.rb
+++ b/zarf@0.29.1.rb
@@ -9,7 +9,7 @@ class ZarfAT0291 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.29.1/zarf_v0.29.1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.29.1/zarf_v0.29.1_Darwin_amd64"
       sha256 "aec06045faed0e7e451af87cbdbe6138ea7e71ba88085c6d6072da111600aa85"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0291 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.29.1/zarf_v0.29.1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.29.1/zarf_v0.29.1_Darwin_arm64"
       sha256 "594aac7cb38a482b875cb8a02cea69a0e0959bb8168b4cf48cb12cfac0f4923b"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0291 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.29.1/zarf_v0.29.1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.29.1/zarf_v0.29.1_Linux_amd64"
       sha256 "46382b034d6a54c150fa7e38f744e2c07076db7e2b67a30699619c9d22129e28"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0291 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.29.1/zarf_v0.29.1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.29.1/zarf_v0.29.1_Linux_arm64"
       sha256 "8dbe479da7c4f51c9c86097e944202c4312ad94e49317875d117e417e936c4cf"
 
       def install

--- a/zarf@0.29.2.rb
+++ b/zarf@0.29.2.rb
@@ -9,7 +9,7 @@ class ZarfAT0292 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.29.2/zarf_v0.29.2_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.29.2/zarf_v0.29.2_Darwin_amd64"
       sha256 "fd943c2a06943a78372c593017a5255e70471ac6bb869a63af59821be7ca8df2"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0292 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.29.2/zarf_v0.29.2_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.29.2/zarf_v0.29.2_Darwin_arm64"
       sha256 "f043d724bcf1e3a7ab0d05b5d38f0e01c629f43a8849024d3ba2ca364a26b83e"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0292 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.29.2/zarf_v0.29.2_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.29.2/zarf_v0.29.2_Linux_amd64"
       sha256 "24d84c80978614aab0cf2aef756b1243c2eb9e563d4e8bd16c0fb8f59d3475e6"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0292 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.29.2/zarf_v0.29.2_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.29.2/zarf_v0.29.2_Linux_arm64"
       sha256 "8a28caf47e192220f32c2eabaab85b2b64f2fb737a860231b27dc7a877e1cc19"
 
       def install

--- a/zarf@0.30.0-rc1.rb
+++ b/zarf@0.30.0-rc1.rb
@@ -9,7 +9,7 @@ class ZarfAT0300Rc1 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.0-rc1/zarf_v0.30.0-rc1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.0-rc1/zarf_v0.30.0-rc1_Darwin_amd64"
       sha256 "157c13fa1fdb567896636d51bf93695607c97e178c9d95122ad3ddff5b48ce22"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0300Rc1 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.0-rc1/zarf_v0.30.0-rc1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.0-rc1/zarf_v0.30.0-rc1_Darwin_arm64"
       sha256 "2d3a1914f221b77224bcb2b3d58d94f15f46abb21dec5549662d0f48c4e43d4a"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0300Rc1 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.0-rc1/zarf_v0.30.0-rc1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.0-rc1/zarf_v0.30.0-rc1_Linux_arm64"
       sha256 "b1e0e9322662323d0d75828a0c71472f63670aac6f581e1ae334ff255f331d16"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0300Rc1 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.0-rc1/zarf_v0.30.0-rc1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.0-rc1/zarf_v0.30.0-rc1_Linux_amd64"
       sha256 "3d35bec17e189a988f8b9b323ebbb69751264d381ad26fdde3783b174b48c3e8"
 
       def install

--- a/zarf@0.30.0-rc2.rb
+++ b/zarf@0.30.0-rc2.rb
@@ -9,7 +9,7 @@ class ZarfAT0300Rc2 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.0-rc2/zarf_v0.30.0-rc2_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.0-rc2/zarf_v0.30.0-rc2_Darwin_arm64"
       sha256 "7492f672c803e1b7880b0ae1e62c922af2bca5a6cf9b7151fe6b7109e81e5b7a"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0300Rc2 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.0-rc2/zarf_v0.30.0-rc2_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.0-rc2/zarf_v0.30.0-rc2_Darwin_amd64"
       sha256 "73b1d4013fd9eb01d2e70a3daa9f475322cc2be41461552d2a14b83db6099996"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0300Rc2 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.0-rc2/zarf_v0.30.0-rc2_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.0-rc2/zarf_v0.30.0-rc2_Linux_amd64"
       sha256 "2224fb86c83a08b9299e9dfcdf2d453ec3c1483bc2381a13a2337c164d6a5769"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0300Rc2 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.0-rc2/zarf_v0.30.0-rc2_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.0-rc2/zarf_v0.30.0-rc2_Linux_arm64"
       sha256 "fbeb6ba2da581dc6e8dc4e27fc94ef7ebfd1aa22026dfea0395f52cd8443a008"
 
       def install

--- a/zarf@0.30.0.rb
+++ b/zarf@0.30.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0300 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.0/zarf_v0.30.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.0/zarf_v0.30.0_Darwin_amd64"
       sha256 "caade7a727ed90e0f609c0e568500b29ff3e983cddac97f2598364dc23b2ce17"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0300 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.0/zarf_v0.30.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.0/zarf_v0.30.0_Darwin_arm64"
       sha256 "018fbd19247bd3c476b35651f1cc376156cecf4e343cfec4a47eb38ce5efd01d"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0300 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.0/zarf_v0.30.0_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.0/zarf_v0.30.0_Linux_arm64"
       sha256 "fe519649b4fa918a4931795780088952644f6cb568684f4aff2cf768a40eb853"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0300 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.0/zarf_v0.30.0_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.0/zarf_v0.30.0_Linux_amd64"
       sha256 "9cbc744d2c25489e41b00868c47edb223daa9b5cd34ae5ff335f8562922a0b73"
 
       def install

--- a/zarf@0.30.1.rb
+++ b/zarf@0.30.1.rb
@@ -9,7 +9,7 @@ class ZarfAT0301 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.1/zarf_v0.30.1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.1/zarf_v0.30.1_Darwin_amd64"
       sha256 "02dfeaf78c108d4a69071863674fddb3905f2fba72cd82e8183e6f5a7028c872"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0301 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.1/zarf_v0.30.1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.1/zarf_v0.30.1_Darwin_arm64"
       sha256 "fadb4c759c0107c9853ed4d86ca2c953755f3d48900ce76196b472b3c0638675"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0301 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.1/zarf_v0.30.1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.1/zarf_v0.30.1_Linux_amd64"
       sha256 "9a3bdbcbf758bb639c13344132293a7533d3b4ebf952adee6a8afbb8b1d3bb4c"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0301 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.30.1/zarf_v0.30.1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.30.1/zarf_v0.30.1_Linux_arm64"
       sha256 "c70cf138040d1955f3cc440e56c4d418c8b36bdda55ac968e9095ccd5f6bded1"
 
       def install

--- a/zarf@0.31.0-rc1.rb
+++ b/zarf@0.31.0-rc1.rb
@@ -9,7 +9,7 @@ class ZarfAT0310Rc1 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.0-rc1/zarf_v0.31.0-rc1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.0-rc1/zarf_v0.31.0-rc1_Darwin_arm64"
       sha256 "d3745b9f7b4ea0bd6d72c5e7656f270a74620495a28ff751c7c83004486331d5"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0310Rc1 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.0-rc1/zarf_v0.31.0-rc1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.0-rc1/zarf_v0.31.0-rc1_Darwin_amd64"
       sha256 "2df0fbfb3735fb52fd4c92290a0f2b3c00a0dce9ded0214f00f30d425cb2d2ee"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0310Rc1 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.0-rc1/zarf_v0.31.0-rc1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.0-rc1/zarf_v0.31.0-rc1_Linux_arm64"
       sha256 "c81241f21dd6b5cc9d24076ed019093688a22ed346578d11d6817a26f5c73b82"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0310Rc1 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.0-rc1/zarf_v0.31.0-rc1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.0-rc1/zarf_v0.31.0-rc1_Linux_amd64"
       sha256 "3f4c97eb2d5890ec66ec11217df5561bcac1d3e101cba6fa00ced94adcde7687"
 
       def install

--- a/zarf@0.31.0.rb
+++ b/zarf@0.31.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0310 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.0/zarf_v0.31.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.0/zarf_v0.31.0_Darwin_amd64"
       sha256 "a086ddc442cf85be0af379aa3b7823b09cbc788b1137a264862dfb06d514d8ff"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0310 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.0/zarf_v0.31.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.0/zarf_v0.31.0_Darwin_arm64"
       sha256 "57d2e84a5f92d4d0a780f83478ae1814f4d3ba10cbab818f63563b05b8fdc8a1"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0310 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.0/zarf_v0.31.0_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.0/zarf_v0.31.0_Linux_amd64"
       sha256 "c1ea290a25d44426064742d898a8075121672714a4cf7d6cc10c20753b43ceac"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0310 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.0/zarf_v0.31.0_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.0/zarf_v0.31.0_Linux_arm64"
       sha256 "c02f37e7312a30ab2d998114ae413427776e5766ab1a11c4967876570cf08729"
 
       def install

--- a/zarf@0.31.1.rb
+++ b/zarf@0.31.1.rb
@@ -9,7 +9,7 @@ class ZarfAT0311 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.1/zarf_v0.31.1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.1/zarf_v0.31.1_Darwin_amd64"
       sha256 "4fe82f4b5112d1b2278d735f3631aa4900371c8bbb9e0476718a9b5a9d7a7c3b"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0311 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.1/zarf_v0.31.1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.1/zarf_v0.31.1_Darwin_arm64"
       sha256 "8a1d899fcf0032921b4e82b03625a38b9b51569affd9df9630af9fba7e766253"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0311 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.1/zarf_v0.31.1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.1/zarf_v0.31.1_Linux_arm64"
       sha256 "d6432c2f1399a6af9951300c47ee15954cf08004f98b3bd0118df124503d5b69"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0311 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.1/zarf_v0.31.1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.1/zarf_v0.31.1_Linux_amd64"
       sha256 "aeab6b5d8d6c2fa23db71a5a224d3904f4c27ddf0842468dc8dd17b5a02b8de9"
 
       def install

--- a/zarf@0.31.2.rb
+++ b/zarf@0.31.2.rb
@@ -9,7 +9,7 @@ class ZarfAT0312 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.2/zarf_v0.31.2_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.2/zarf_v0.31.2_Darwin_arm64"
       sha256 "dfe63bcb518605c3e15bc14fd41f8a01fddfaf708981faeb4d58ea634d1d0657"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0312 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.2/zarf_v0.31.2_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.2/zarf_v0.31.2_Darwin_amd64"
       sha256 "973d2962a0dc484b832ce46e36fec68398312fff5e95a33787c1ac728a1d9866"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0312 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.2/zarf_v0.31.2_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.2/zarf_v0.31.2_Linux_amd64"
       sha256 "2df0bbe70e1a82e459b21aec891e629b218d4c00d7e35453e36ffc63d04790f9"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0312 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.2/zarf_v0.31.2_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.2/zarf_v0.31.2_Linux_arm64"
       sha256 "29c6a20879b5c9d46b81eff64d57d64b8d04a95d18efd8ecc509f50eef477277"
 
       def install

--- a/zarf@0.31.3.rb
+++ b/zarf@0.31.3.rb
@@ -9,7 +9,7 @@ class ZarfAT0313 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.3/zarf_v0.31.3_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.3/zarf_v0.31.3_Darwin_amd64"
       sha256 "f3582dedb3aea66c51792857111485b437bc00d2427e2d6e46843898eb460626"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0313 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.3/zarf_v0.31.3_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.3/zarf_v0.31.3_Darwin_arm64"
       sha256 "e6ee1ccc1679e8ad352094c31a6dc39831ac0ae6981e60b0aa5a1017b06eab9e"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0313 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.3/zarf_v0.31.3_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.3/zarf_v0.31.3_Linux_arm64"
       sha256 "28f5d978dc07d5b91d6f0a4a42a5a5f4a116fc5bf1e51e9c285c8316de472f21"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0313 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.3/zarf_v0.31.3_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.3/zarf_v0.31.3_Linux_amd64"
       sha256 "2dcea609910b0a3fe6d65e98d840d75856a5954b3a29587a87c4de10735e42a3"
 
       def install

--- a/zarf@0.31.4.rb
+++ b/zarf@0.31.4.rb
@@ -9,7 +9,7 @@ class ZarfAT0314 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.4/zarf_v0.31.4_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.4/zarf_v0.31.4_Darwin_amd64"
       sha256 "9f56c197a3ef461a516afc31f77b49ecdbae518f8ae43a498ed479269c2b5737"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0314 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.4/zarf_v0.31.4_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.4/zarf_v0.31.4_Darwin_arm64"
       sha256 "044c873054e66aa5a68cabc56050621e834c85c978c618aaa2289139c754db8c"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0314 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.4/zarf_v0.31.4_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.4/zarf_v0.31.4_Linux_arm64"
       sha256 "1030a0884e3444f07f9b2a996b25d0ecf9aaf14cf309d30cca9abcf88bfc29c8"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0314 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.31.4/zarf_v0.31.4_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.31.4/zarf_v0.31.4_Linux_amd64"
       sha256 "975c6afbf87ff824fc0f2db3096da009cf2a967bc0693f46027c6d94e07d43d9"
 
       def install

--- a/zarf@0.32.0-rc1.rb
+++ b/zarf@0.32.0-rc1.rb
@@ -9,7 +9,7 @@ class ZarfAT0320Rc1 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Darwin_amd64"
       sha256 "58bd7f9bb4801b415d0968fa7c08965fc8159350af78c3c246c5075544405143"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0320Rc1 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Darwin_arm64"
       sha256 "84c642e5fad6150bc06741076ac701046e731544f42b0afcb56d5288b4ec2d9f"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0320Rc1 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Linux_amd64"
       sha256 "0d42b6917eec0288eb3d0e361b28f12cddf7a12ec5865eaaa68638b9ad7135cd"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0320Rc1 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Linux_arm64"
       sha256 "5a343ed0b6e22db75de8abe68e1004d501d2ec87eec29bb0cbb6ca958e8b579c"
 
       def install

--- a/zarf@0.32.0.rb
+++ b/zarf@0.32.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0320 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.0/zarf_v0.32.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.0/zarf_v0.32.0_Darwin_arm64"
       sha256 "301765fc62b28d75c24c08a0074ad56395c25a09f37b957a5708181759014c97"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0320 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.0/zarf_v0.32.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.0/zarf_v0.32.0_Darwin_amd64"
       sha256 "0bf7252c15a14d4f0eecf272f56c4e0e61dae4f372d75604ae25b841e0bec7fc"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0320 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.0/zarf_v0.32.0_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.0/zarf_v0.32.0_Linux_amd64"
       sha256 "ae913af3cf83a35b014fa47911a872124edc291e95a61bd509f143d95ec9d5ab"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0320 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.0/zarf_v0.32.0_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.0/zarf_v0.32.0_Linux_arm64"
       sha256 "a213695b7a58482affab4136560d976f308f25585a5218ecb5cedb28050f639a"
 
       def install

--- a/zarf@0.32.1.rb
+++ b/zarf@0.32.1.rb
@@ -9,7 +9,7 @@ class ZarfAT0321 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.1/zarf_v0.32.1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.1/zarf_v0.32.1_Darwin_arm64"
       sha256 "8eac9f57fd7de050e2075d4fa6737554915e22af95870a49053ebf53ca2ea2f6"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0321 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.1/zarf_v0.32.1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.1/zarf_v0.32.1_Darwin_amd64"
       sha256 "aacd448370906c001887fb02566f09e42af5e0ba411b3c771f2e457f0b314ee5"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0321 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.1/zarf_v0.32.1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.1/zarf_v0.32.1_Linux_amd64"
       sha256 "45cb910abd9396f9633d482e7cd6102e6a677c647b33efb718f916303a5e2b0a"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0321 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.1/zarf_v0.32.1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.1/zarf_v0.32.1_Linux_arm64"
       sha256 "25fa7c7ef0973856cd5b666313d24bf899af58247ba0318bea3bb87c9b365d4b"
 
       def install

--- a/zarf@0.32.2.rb
+++ b/zarf@0.32.2.rb
@@ -9,7 +9,7 @@ class ZarfAT0322 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.2/zarf_v0.32.2_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.2/zarf_v0.32.2_Darwin_arm64"
       sha256 "99f5153a8647a99c5a753d884d94c2febd52745d681c019c497920b35245e522"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0322 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.2/zarf_v0.32.2_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.2/zarf_v0.32.2_Darwin_amd64"
       sha256 "05e308bcfd9db6bd2451dcb40fedac0ed931f822836823290bddd65954b37934"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0322 < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.2/zarf_v0.32.2_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.2/zarf_v0.32.2_Linux_arm64"
       sha256 "639fc0548ab38ac66879d43570029f861ea2f5213f409c81a023718682ee4090"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0322 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.2/zarf_v0.32.2_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.2/zarf_v0.32.2_Linux_amd64"
       sha256 "d2160f15411ac313c776bdfa70cb8e004ff1b534c10f35aec903043652503631"
 
       def install

--- a/zarf@0.32.3.rb
+++ b/zarf@0.32.3.rb
@@ -9,7 +9,7 @@ class ZarfAT0323 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.3/zarf_v0.32.3_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.3/zarf_v0.32.3_Darwin_arm64"
       sha256 "3786c2c4a6d20a227340cbab62c025a6d3d1fd185f33425961a28887451b0819"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0323 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.3/zarf_v0.32.3_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.3/zarf_v0.32.3_Darwin_amd64"
       sha256 "a1ad2d22dc9536b0fcdc00479e13f2394874096babafb575df5af529fafeb8c8"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0323 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.3/zarf_v0.32.3_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.3/zarf_v0.32.3_Linux_amd64"
       sha256 "1e73b39fac2d513ec444abc84bb50a542e2e34d62ee14bd71c4915d32a3b2765"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0323 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.3/zarf_v0.32.3_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.3/zarf_v0.32.3_Linux_arm64"
       sha256 "f38dfa54282876ddffd64d12aa66460d056c4eeeb432575c6c0f499a62fa39b0"
 
       def install

--- a/zarf@0.32.4.rb
+++ b/zarf@0.32.4.rb
@@ -9,7 +9,7 @@ class ZarfAT0324 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.4/zarf_v0.32.4_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.4/zarf_v0.32.4_Darwin_arm64"
       sha256 "750731d55372c8d4e523cdecbdb6dc651d3d360696b00164effbdad081d32df1"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0324 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.4/zarf_v0.32.4_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.4/zarf_v0.32.4_Darwin_amd64"
       sha256 "a33fa7170ad0c5af9908785945693da27f25ed01ff8684891a80125a300b15a9"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0324 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.4/zarf_v0.32.4_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.4/zarf_v0.32.4_Linux_amd64"
       sha256 "9f4283ce66842a3c24083d13c6e4cbd94ba556e959ba84c22b49ff2a47b6363a"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0324 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.4/zarf_v0.32.4_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.4/zarf_v0.32.4_Linux_arm64"
       sha256 "7a14ed53fbc67f3f46fba9b0180f9779c1c1c3486ef148c54e734e88b42beecf"
 
       def install

--- a/zarf@0.32.5.rb
+++ b/zarf@0.32.5.rb
@@ -9,7 +9,7 @@ class ZarfAT0325 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.5/zarf_v0.32.5_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.5/zarf_v0.32.5_Darwin_arm64"
       sha256 "2e7926cf7a561acbe8c8bf359785a3d4c27592017d25a977ca4e85f1ec3083be"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0325 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.5/zarf_v0.32.5_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.5/zarf_v0.32.5_Darwin_amd64"
       sha256 "cb1408cd1eea3348a5b48f596ca4a2d972b39e2f1840eea453ba6c72afde8bbd"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0325 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.5/zarf_v0.32.5_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.5/zarf_v0.32.5_Linux_amd64"
       sha256 "0232671ff28d9756ebeedfbcbfe0e12e3614cdcdb12180be33261c16c5f36dd7"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0325 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.5/zarf_v0.32.5_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.5/zarf_v0.32.5_Linux_arm64"
       sha256 "99b42602c4c6856397d6a18b1ed23403e89b63d20882a317c3f539c9f6b22070"
 
       def install

--- a/zarf@0.32.6.rb
+++ b/zarf@0.32.6.rb
@@ -9,7 +9,7 @@ class ZarfAT0326 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.6/zarf_v0.32.6_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.6/zarf_v0.32.6_Darwin_arm64"
       sha256 "b0217e468e6f95f9e71a4f2ec8a7accd67a20c9a72c68ff9a5074e593f78c85a"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0326 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.6/zarf_v0.32.6_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.6/zarf_v0.32.6_Darwin_amd64"
       sha256 "8648050e02cd63a0994f4ae8c03395ad235bc77490a7d232d4acdc5a4a57eb83"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0326 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.6/zarf_v0.32.6_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.6/zarf_v0.32.6_Linux_amd64"
       sha256 "118f7622bae15ab1ba30837c7b73025e791b609f5bd1a8749cd71f7dfab20184"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0326 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.6/zarf_v0.32.6_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.6/zarf_v0.32.6_Linux_arm64"
       sha256 "501788ead7be8ecc10c1fb5aaffede6c961a8cb1b76aeb892e4abde74380444f"
 
       def install

--- a/zarf@0.33.0.rb
+++ b/zarf@0.33.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0330 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.33.0/zarf_v0.33.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.33.0/zarf_v0.33.0_Darwin_amd64"
       sha256 "a89981fe71b1d1316006143d2b576d136acc5c3c1d11b3868a5f451a928f3b2a"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0330 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.33.0/zarf_v0.33.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.33.0/zarf_v0.33.0_Darwin_arm64"
       sha256 "690576ddfce315d3f188931e104014a5dc893feb85ba1ddcafbbe039301ebc97"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0330 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.33.0/zarf_v0.33.0_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.33.0/zarf_v0.33.0_Linux_amd64"
       sha256 "79eb20d54188ebe83d2f10bbc5235bac605dbe77b73dc272780e33656370952a"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0330 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.33.0/zarf_v0.33.0_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.33.0/zarf_v0.33.0_Linux_arm64"
       sha256 "158b949b7a246cd987ce583639b18fbe88c3d34669b23e765d9f161b23e85a27"
 
       def install

--- a/zarf@0.33.1.rb
+++ b/zarf@0.33.1.rb
@@ -9,7 +9,7 @@ class ZarfAT0331 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.33.1/zarf_v0.33.1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.33.1/zarf_v0.33.1_Darwin_amd64"
       sha256 "fa65da423235900c273d2713f86b6c85e31b45270094f8756406b5e1e9e3db4a"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0331 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.33.1/zarf_v0.33.1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.33.1/zarf_v0.33.1_Darwin_arm64"
       sha256 "2a4d67d5641651b5866a2c0d037522d39231127ac82dd270a580f79a0bc8366c"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0331 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.33.1/zarf_v0.33.1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.33.1/zarf_v0.33.1_Linux_amd64"
       sha256 "d2c2c1a3e6f582057dee1186e89de47886dee35b1297cb0b7f796d4db1391f5e"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0331 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.33.1/zarf_v0.33.1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.33.1/zarf_v0.33.1_Linux_arm64"
       sha256 "bdcc7b600161e4ac5a0f821473a1df5b2b85506ac0efd580cc302db848b50466"
 
       def install

--- a/zarf@0.33.2.rb
+++ b/zarf@0.33.2.rb
@@ -9,7 +9,7 @@ class ZarfAT0332 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.33.2/zarf_v0.33.2_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.33.2/zarf_v0.33.2_Darwin_amd64"
       sha256 "135f9d52271307a8ceb3eefaa20809ed33e4ffca3bcdb11dad46f505efa6a3ba"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0332 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.33.2/zarf_v0.33.2_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.33.2/zarf_v0.33.2_Darwin_arm64"
       sha256 "069b47ef1576c12033678cdf6971fe20e7ed81768c7f18de1d5e4eadb8762413"
 
       def install
@@ -28,7 +28,7 @@ class ZarfAT0332 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.33.2/zarf_v0.33.2_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.33.2/zarf_v0.33.2_Linux_amd64"
       sha256 "039c6e7b04379f8435f36c55c6e616077aa1de6be1d3a962734497f7b7ae4722"
 
       def install
@@ -36,7 +36,7 @@ class ZarfAT0332 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.33.2/zarf_v0.33.2_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.33.2/zarf_v0.33.2_Linux_arm64"
       sha256 "d43ebe295a83f091fe5216fb75e835f39a208836034670f47723a4db564e6a4f"
 
       def install

--- a/zarf@0.34.0.rb
+++ b/zarf@0.34.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0340 < Formula
 
   on_macos do
     on_intel do
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.34.0/zarf_v0.34.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.34.0/zarf_v0.34.0_Darwin_amd64"
       sha256 "28d3456463fbdf58b232b976da2f56dff7f4d928ef908409f39adfba2cc93c2e"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0340 < Formula
       end
     end
     on_arm do
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.34.0/zarf_v0.34.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.34.0/zarf_v0.34.0_Darwin_arm64"
       sha256 "ab976da57d9c7e03e09b686f11a2a4841d854910c18132feec825ebd096f98a6"
 
       def install
@@ -29,7 +29,7 @@ class ZarfAT0340 < Formula
   on_linux do
     on_intel do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/defenseunicorns/zarf/releases/download/v0.34.0/zarf_v0.34.0_Linux_amd64"
+        url "https://github.com/zarf-dev/zarf/releases/download/v0.34.0/zarf_v0.34.0_Linux_amd64"
         sha256 "c7eba354ddccd3a65fbcfea1778df9f44c73facabc02dbaac42d006df01831ab"
 
         def install
@@ -39,7 +39,7 @@ class ZarfAT0340 < Formula
     end
     on_arm do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/defenseunicorns/zarf/releases/download/v0.34.0/zarf_v0.34.0_Linux_arm64"
+        url "https://github.com/zarf-dev/zarf/releases/download/v0.34.0/zarf_v0.34.0_Linux_arm64"
         sha256 "e1f3323b4e547e1eec560eedbae435164c05d5836d6f0ab8a07de8d4f9c8ed05"
 
         def install

--- a/zarf@0.35.0.rb
+++ b/zarf@0.35.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0350 < Formula
 
   on_macos do
     on_intel do
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.35.0/zarf_v0.35.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.35.0/zarf_v0.35.0_Darwin_amd64"
       sha256 "8fd5a8c181972f206857187829dc37fd25f875d919c4aa54cedbba3d87aa1fa9"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0350 < Formula
       end
     end
     on_arm do
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.35.0/zarf_v0.35.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.35.0/zarf_v0.35.0_Darwin_arm64"
       sha256 "5bbfac41e9f2677b17c6f0f77a6a28ef84edf5b95d9e7718534c09cbb0ddf65b"
 
       def install
@@ -29,7 +29,7 @@ class ZarfAT0350 < Formula
   on_linux do
     on_intel do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/defenseunicorns/zarf/releases/download/v0.35.0/zarf_v0.35.0_Linux_amd64"
+        url "https://github.com/zarf-dev/zarf/releases/download/v0.35.0/zarf_v0.35.0_Linux_amd64"
         sha256 "cc5aa949538e2773622e03c46f3e489bdd8b8a8242d3921d72e0eed03c991e27"
 
         def install
@@ -39,7 +39,7 @@ class ZarfAT0350 < Formula
     end
     on_arm do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/defenseunicorns/zarf/releases/download/v0.35.0/zarf_v0.35.0_Linux_arm64"
+        url "https://github.com/zarf-dev/zarf/releases/download/v0.35.0/zarf_v0.35.0_Linux_arm64"
         sha256 "92f75f1ffcbc6aaab5729bc8d2a532a15496c8efd4f8e15f1fda235f68d282d1"
 
         def install

--- a/zarf@0.36.0.rb
+++ b/zarf@0.36.0.rb
@@ -9,7 +9,7 @@ class ZarfAT0360 < Formula
 
   on_macos do
     on_intel do
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.36.0/zarf_v0.36.0_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.36.0/zarf_v0.36.0_Darwin_amd64"
       sha256 "5c6172c8382f54c0da7e3c122eabb5a60e1413db4fe2f730a14982986f8ffa71"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0360 < Formula
       end
     end
     on_arm do
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.36.0/zarf_v0.36.0_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.36.0/zarf_v0.36.0_Darwin_arm64"
       sha256 "4187ae1493241f2c9bb6550048d002d26098e0901921eec00f6284cc2fea849f"
 
       def install
@@ -29,7 +29,7 @@ class ZarfAT0360 < Formula
   on_linux do
     on_intel do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/defenseunicorns/zarf/releases/download/v0.36.0/zarf_v0.36.0_Linux_amd64"
+        url "https://github.com/zarf-dev/zarf/releases/download/v0.36.0/zarf_v0.36.0_Linux_amd64"
         sha256 "d6e910a9fb95fbe17b049421c0973b9e671cb45779ec8ddd5489816015bd5023"
 
         def install
@@ -39,7 +39,7 @@ class ZarfAT0360 < Formula
     end
     on_arm do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/defenseunicorns/zarf/releases/download/v0.36.0/zarf_v0.36.0_Linux_arm64"
+        url "https://github.com/zarf-dev/zarf/releases/download/v0.36.0/zarf_v0.36.0_Linux_arm64"
         sha256 "44637411f5f569af0622a185f53f000a72f371f986583c923cecb00ce400f756"
 
         def install

--- a/zarf@0.36.1.rb
+++ b/zarf@0.36.1.rb
@@ -9,7 +9,7 @@ class ZarfAT0361 < Formula
 
   on_macos do
     on_intel do
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.36.1/zarf_v0.36.1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.36.1/zarf_v0.36.1_Darwin_amd64"
       sha256 "3508e9e79a5caa5ad08f7950b8b2910a19c6f47dc5c9da1b1defa4183f9b306e"
 
       def install
@@ -17,7 +17,7 @@ class ZarfAT0361 < Formula
       end
     end
     on_arm do
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.36.1/zarf_v0.36.1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.36.1/zarf_v0.36.1_Darwin_arm64"
       sha256 "409c3b922f1bad59afbd1f0da38087f70c067f0ad6297eaad7baac0cba8819cc"
 
       def install
@@ -29,7 +29,7 @@ class ZarfAT0361 < Formula
   on_linux do
     on_intel do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/defenseunicorns/zarf/releases/download/v0.36.1/zarf_v0.36.1_Linux_amd64"
+        url "https://github.com/zarf-dev/zarf/releases/download/v0.36.1/zarf_v0.36.1_Linux_amd64"
         sha256 "10c61cd0c6b41cea3ddfecdff202f399df2a0b665f14a84f2bfee8dd2ffcc0c7"
 
         def install
@@ -39,7 +39,7 @@ class ZarfAT0361 < Formula
     end
     on_arm do
       if Hardware::CPU.is_64_bit?
-        url "https://github.com/defenseunicorns/zarf/releases/download/v0.36.1/zarf_v0.36.1_Linux_arm64"
+        url "https://github.com/zarf-dev/zarf/releases/download/v0.36.1/zarf_v0.36.1_Linux_arm64"
         sha256 "0be840b59c760b1b2a420d2e408296b699b8704ea2b19f019cfe716847f393ca"
 
         def install

--- a/zarf@latest-rc.rb
+++ b/zarf@latest-rc.rb
@@ -9,7 +9,7 @@ class ZarfATlatestRc < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Darwin_amd64"
       sha256 "58bd7f9bb4801b415d0968fa7c08965fc8159350af78c3c246c5075544405143"
 
       def install
@@ -17,7 +17,7 @@ class ZarfATlatestRc < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Darwin_arm64"
       sha256 "84c642e5fad6150bc06741076ac701046e731544f42b0afcb56d5288b4ec2d9f"
 
       def install
@@ -28,7 +28,7 @@ class ZarfATlatestRc < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Linux_amd64"
       sha256 "0d42b6917eec0288eb3d0e361b28f12cddf7a12ec5865eaaa68638b9ad7135cd"
 
       def install
@@ -36,7 +36,7 @@ class ZarfATlatestRc < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.32.0-rc1/zarf_v0.32.0-rc1_Linux_arm64"
       sha256 "5a343ed0b6e22db75de8abe68e1004d501d2ec87eec29bb0cbb6ca958e8b579c"
 
       def install

--- a/zarf@v0.22.1.rb
+++ b/zarf@v0.22.1.rb
@@ -9,7 +9,7 @@ class ZarfATv0.22.1 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.22.1/zarf_v0.22.1_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.22.1/zarf_v0.22.1_Darwin_arm64"
       sha256 "796b8e16d021a16c41f31d23c9b2d57772d64336a0a12a75dba8514b0bdf0c04"
 
       def install
@@ -17,7 +17,7 @@ class ZarfATv0.22.1 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.22.1/zarf_v0.22.1_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.22.1/zarf_v0.22.1_Darwin_amd64"
       sha256 "76755651f8dfee2dd4f3f58c600e9d7dc0ad763287ba999a5c07cbe010b483d2"
 
       def install
@@ -28,7 +28,7 @@ class ZarfATv0.22.1 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.22.1/zarf_v0.22.1_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.22.1/zarf_v0.22.1_Linux_amd64"
       sha256 "46e76a7afaaeb3a9ac717b3998c6457716fd869fa9f2c5448e985b5ce7caa7ce"
 
       def install
@@ -36,7 +36,7 @@ class ZarfATv0.22.1 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.22.1/zarf_v0.22.1_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.22.1/zarf_v0.22.1_Linux_arm64"
       sha256 "5bd8549d3cb7b0e44b350019b651a62fa554cbd521db8d20ed0822ebaa82ab56"
 
       def install

--- a/zarf@v0.23.0-rc2.rb
+++ b/zarf@v0.23.0-rc2.rb
@@ -9,7 +9,7 @@ class ZarfATv0230Rc2 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc2/zarf_v0.23.0-rc2_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc2/zarf_v0.23.0-rc2_Darwin_amd64"
       sha256 "2996e573682bef114872e25b38e7f56c99071f5b1aefc92a4989475357a138bd"
 
       def install
@@ -17,7 +17,7 @@ class ZarfATv0230Rc2 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc2/zarf_v0.23.0-rc2_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc2/zarf_v0.23.0-rc2_Darwin_arm64"
       sha256 "a0224abf646cae58fe7c3bbd9c70c6229fb8ecc6ad341605a786949d6114bfb2"
 
       def install
@@ -28,7 +28,7 @@ class ZarfATv0230Rc2 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc2/zarf_v0.23.0-rc2_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc2/zarf_v0.23.0-rc2_Linux_amd64"
       sha256 "5b5413ec45985bacf30c1803f7404d8c384f16559e64a76cdb725ea834bbbee2"
 
       def install
@@ -36,7 +36,7 @@ class ZarfATv0230Rc2 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc2/zarf_v0.23.0-rc2_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc2/zarf_v0.23.0-rc2_Linux_arm64"
       sha256 "a994ad7f109adc7a26ab0e98467b362f71dc039822f92b8725e7870e669a9f3b"
 
       def install

--- a/zarf@v0.23.0-rc3.rb
+++ b/zarf@v0.23.0-rc3.rb
@@ -9,7 +9,7 @@ class ZarfATv0230Rc3 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc3/zarf_v0.23.0-rc3_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc3/zarf_v0.23.0-rc3_Darwin_amd64"
       sha256 "ab3fc31c5f6e2f40c3be2861fe8d39a06861c00854d6ca070f190fd8131270dd"
 
       def install
@@ -17,7 +17,7 @@ class ZarfATv0230Rc3 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc3/zarf_v0.23.0-rc3_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc3/zarf_v0.23.0-rc3_Darwin_arm64"
       sha256 "37800b680dc5ac61b5d3e7ee66dfd05309f7aa321a0bce7e3735fabeb3fc15a9"
 
       def install
@@ -28,7 +28,7 @@ class ZarfATv0230Rc3 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc3/zarf_v0.23.0-rc3_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc3/zarf_v0.23.0-rc3_Linux_amd64"
       sha256 "85f4326ce8d41317fc8f5ea472934c085d7d678c8f4878416f30fa3e155882a3"
 
       def install
@@ -36,7 +36,7 @@ class ZarfATv0230Rc3 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc3/zarf_v0.23.0-rc3_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc3/zarf_v0.23.0-rc3_Linux_arm64"
       sha256 "7a1c023df7f93e73a6901b29c85ed8924e82ab65272bc9e10e1b9720bfc5fca0"
 
       def install

--- a/zarf@v0.23.0-rc4.rb
+++ b/zarf@v0.23.0-rc4.rb
@@ -9,7 +9,7 @@ class ZarfATv0230Rc4 < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc4/zarf_v0.23.0-rc4_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc4/zarf_v0.23.0-rc4_Darwin_amd64"
       sha256 "e3525607bca03fc2a57da54c960ad1567b4740018e1b3e90488084ff57fb9d16"
 
       def install
@@ -17,7 +17,7 @@ class ZarfATv0230Rc4 < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc4/zarf_v0.23.0-rc4_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc4/zarf_v0.23.0-rc4_Darwin_arm64"
       sha256 "a1ec7adacbcade7a6cafd0199fcbe33b42c863bb2ae7be993f8e55987c2233d6"
 
       def install
@@ -28,7 +28,7 @@ class ZarfATv0230Rc4 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc4/zarf_v0.23.0-rc4_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc4/zarf_v0.23.0-rc4_Linux_amd64"
       sha256 "b2aba49035b42cd56e4986a82cbfce668ddd6b76d9c12ebe32594f13775f354e"
 
       def install
@@ -36,7 +36,7 @@ class ZarfATv0230Rc4 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc4/zarf_v0.23.0-rc4_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc4/zarf_v0.23.0-rc4_Linux_arm64"
       sha256 "00dcc7ee69584885925e3f6b4ae15f282d959916fea9bec6485d9f4af8a7af6d"
 
       def install

--- a/zarf@v0.23.0-rc5.rb
+++ b/zarf@v0.23.0-rc5.rb
@@ -9,7 +9,7 @@ class ZarfATv0230Rc5 < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc5/zarf_v0.23.0-rc5_Darwin_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc5/zarf_v0.23.0-rc5_Darwin_arm64"
       sha256 "0cc3fb258315a7ae476e60cbb4447b341e07d0a00b95fb0265a9ea01c9998ede"
 
       def install
@@ -17,7 +17,7 @@ class ZarfATv0230Rc5 < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc5/zarf_v0.23.0-rc5_Darwin_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc5/zarf_v0.23.0-rc5_Darwin_amd64"
       sha256 "833ee62fdc3fb336a77e344bebc3685c1ebca7237ed97057df0bf20ef46d61c8"
 
       def install
@@ -28,7 +28,7 @@ class ZarfATv0230Rc5 < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc5/zarf_v0.23.0-rc5_Linux_amd64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc5/zarf_v0.23.0-rc5_Linux_amd64"
       sha256 "c253fd03841826554a4a2cd3232ae78ba7341fbb86e49dbbe1e0fa609deda3e6"
 
       def install
@@ -36,7 +36,7 @@ class ZarfATv0230Rc5 < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/defenseunicorns/zarf/releases/download/v0.23.0-rc5/zarf_v0.23.0-rc5_Linux_arm64"
+      url "https://github.com/zarf-dev/zarf/releases/download/v0.23.0-rc5/zarf_v0.23.0-rc5_Linux_arm64"
       sha256 "fdc22c88fea45f42116b102d5059cd854cb33e6df0570570241d9cb47da1e369"
 
       def install


### PR DESCRIPTION
This should knock down a large number of dangling references to the old `defenseunicorns/zarf` organization.