### PR TITLE
chore: update codeowners to foundation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
 /* @defenseunicorns/homebrew-tap
 
-/uds* @defenseunicorns/uds-cli
+/uds* @defenseunicorns/uds-foundation
 /zarf* @defenseunicorns/zarf-admin
-/maru* @defenseunicorns/uds-cli
+/maru* @defenseunicorns/uds-foundation
 
 # Additional privileged files
 /CODEOWNERS @jeff-mccoy @daveworth


### PR DESCRIPTION
Updates to the foundation team. Someone with repo permissions will need to add this team to explicitly have write permissions on the repo.